### PR TITLE
Allow a fakeroot instead of trying to figure it out through the id property

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ function expandSchema(schemaText, fakeRoot) {
     if (schemaText.indexOf("$ref") > 0 && isJsonSchema(schemaText)) {
         var schemaObject = JSON.parse(schemaText);
         if (schemaObject.id) {
-            var expandedSchema = walkTree(fakeRoot, schemaObject, fakeRoot);
+            var expandedSchema = walkTree(schemaObject, fakeRoot);
             expandedSchemaCache[schemaObject.id] = expandedSchema;
             return JSON.stringify(expandedSchema, null, 2);
         } else {


### PR DESCRIPTION
This is required for the following pull request in raml2html: https://github.com/raml2html/raml2html/pull/196
