### PR TITLE
Hotfix/objtostringpatch

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,11 @@ function fixSchemaNodesInArray(value) {
 }
 
 function expandSchema(schemaText) {
+    // if we don't start with a string, we have to make it a string
+    // so {}.indexOf() doesn't make things blow up.
+    if (typeof SchemaText === 'object') {
+	schemaText = JSON.stringify(schemaText);
+    }
     if (schemaText.indexOf("$ref") > 0 && isJsonSchema(schemaText)) {
         var schemaObject = JSON.parse(schemaText);
         if (schemaObject.id) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raml-jsonschema-expander",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Expands JSON Schema draft 4 references from a RAML object created with raml2obj.",
   "homepage": "https://github.com/br-adam-newman/raml-jsonschema-expander",
   "author": {


### PR DESCRIPTION
`expandSchema` wasn't always getting a `String`, and that resulted in a TypeError being thrown due to `indexOf` not being a function.
